### PR TITLE
feat: listen for workspace vim-mode-changed events

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -70,6 +70,21 @@ export default class VimImSwitcher extends Plugin {
 		this.registerEvent(
 			this.app.workspace.on("file-open", this.registerWorkspaceEvent),
 		);
+
+		// Listen for vim-mode-changed events from any plugin (e.g. non-MarkdownView editors).
+		// This allows third-party plugins with standalone CodeMirror vim editors to
+		// trigger IME switching by firing: app.workspace.trigger("vim-mode-changed", { mode })
+		this.registerEvent(
+			(this.app.workspace as any).on(
+				"vim-mode-changed",
+				async (modeObj: { mode: string }) => {
+					if (!this.isInitialized) {
+						await this.initialize();
+					}
+					this.onVimModeChanged(modeObj);
+				},
+			),
+		);
 	}
 
 	private async initialize() {
@@ -128,7 +143,9 @@ export default class VimImSwitcher extends Plugin {
 		}
 
 		// run commands when vim mode has changed
-		editor.on("vim-mode-change", (modeObj: any) => {
+		// "vim-mode-change" is not in CodeMirror's type definitions but is
+		// fired by the vim extension at runtime.
+		(editor as any).on("vim-mode-change", (modeObj: { mode: string }) => {
 			if (modeObj) {
 				this.onVimModeChanged(modeObj);
 			}


### PR DESCRIPTION
## Why

Third-party plugins with standalone CodeMirror vim editors (non-MarkdownView) cannot trigger IM switching because the plugin only listens for `vim-mode-change` events on MarkdownView editors.

## What

- Add workspace-level `vim-mode-changed` event listener so any plugin can trigger IM switching via `app.workspace.trigger('vim-mode-changed', { mode })`
- Improve type safety: cast editor to `any` for the non-typed `vim-mode-change` event and type `modeObj` parameter
- Use `WeakSet` for editor tracking (already in this commit)